### PR TITLE
Add AI Weekly to RSS favorites

### DIFF
--- a/feeds/feed_favorites.md
+++ b/feeds/feed_favorites.md
@@ -705,5 +705,13 @@ An iOS blog
 https://swiftlogic.io/feed.xml
 ```
 
+### [AI Weekly](https://aiweekly.co/)
+
+Discover what AI experts are reading and sharing right now, with new editions three times a week.
+
+```
+https://aiweekly.co/feed
+```
+
 
 <!--RSS_FAVORITES_LIST_END-->

--- a/feeds/feed_favorites.zh.md
+++ b/feeds/feed_favorites.zh.md
@@ -706,4 +706,12 @@ https://swiftlogic.io/feed.xml
 ```
 
 
+### [AI Weekly](https://aiweekly.co/)
+
+了解 AI 专家正在阅读和分享的内容，每周更新三次。
+
+```
+https://aiweekly.co/feed
+```
+
 <!--RSS_FAVORITES_LIST_END-->

--- a/feeds/opml.xml
+++ b/feeds/opml.xml
@@ -95,5 +95,6 @@
     <outline text="Stories by Jakir Hossain on Medium" title="Stories by Jakir Hossain on Medium" xmlUrl="https://medium.com/feed/@jakir" htmlUrl="https://medium.com/@jakir?source=rss-3ef993a5539a------2" description="Stories by Jakir Hossain on Medium" type="rss" />
     <outline text="Xojo Programming Blog" title="Xojo Programming Blog" xmlUrl="https://blog.xojo.com/feed/" htmlUrl="https://blog.xojo.com" description="Blog about the Xojo programming language and IDE" type="rss" />
     <outline text="Osas Blogs" title="Osas Blogs" xmlUrl="https://swiftlogic.io/feed.xml" htmlUrl="https://swiftlogic.io/feed.xml" description="An iOS blog" type="rss" />
+    <outline text="AI Weekly" title="AI Weekly" xmlUrl="https://aiweekly.co/feed" htmlUrl="https://aiweekly.co/" description="Discover what AI experts are reading and sharing right now, with new editions three times a week." type="rss" />
   </body>
 </opml>


### PR DESCRIPTION
## Summary

Add AI Weekly to the RSS favorites collection, its Chinese mirror, and the importable OPML file.

## Verification

- Confirmed the feed returns valid RSS 2.0.
- `xmllint --noout feeds/opml.xml`
- `git diff --check`

## Disclosure

I am the founder of AI Weekly. I used an AI assistant to help prepare this narrowly scoped contribution and reviewed the submitted wording and diff.
